### PR TITLE
Update addon options for War Within

### DIFF
--- a/ValorMount/ValorMount.lua
+++ b/ValorMount/ValorMount.lua
@@ -1157,9 +1157,6 @@ category, layout = Settings.RegisterCanvasLayoutCategory(vmPrefs, vmPrefs.name, 
 category.ID = vmPrefs.name
 Settings.RegisterAddOnCategory(category);
 
-
-_G.InterfaceOptions_AddCategory(vmPrefs)
-
 -- Slash Commands and Key Bindings
 -------------------------------------------------
 _G["BINDING_NAME_VALORMOUNTBINDING1"] = "Mount/Dismount"
@@ -1167,8 +1164,5 @@ _G["BINDING_HEADER_VALORMOUNT"] = "ValorMount"
 _G.SLASH_VALORMOUNT1 = "/valormount"
 _G.SLASH_VALORMOUNT2 = "/vm"
 _G.SlashCmdList.VALORMOUNT = function()
-	if not vmPrefs.contentFrame.fromTop then
-Settings.OpenToCategory(category.ID)	--	_G.InterfaceOptionsFrame_OpenToCategory(vmPrefs)
-	end
-Settings.OpenToCategory(category.ID)	--_G.InterfaceOptionsFrame_OpenToCategory(vmPrefs)
+        Settings.OpenToCategory(category.ID)
 end

--- a/ValorMount/ValorMount.toc
+++ b/ValorMount/ValorMount.toc
@@ -1,4 +1,4 @@
-## Interface: 100002
+## Interface: 110000
 ## Title: ValorMount
 ## Notes: A fairly simple mount manager.
 ## Author: darkValorous


### PR DESCRIPTION
## Summary
- update interface version for War Within
- register options only with the modern `Settings` API
- simplify slash command to open the addon options

## Testing
- `luac` not available

------
https://chatgpt.com/codex/tasks/task_e_687c0976ad70832eb90d126386deba41