### PR TITLE
Fix ValorMount options not visible

### DIFF
--- a/ValorMount/ValorMount.lua
+++ b/ValorMount/ValorMount.lua
@@ -1144,11 +1144,9 @@ vmPrefs.contentFrame = CreateFrame("Frame", nil, vmPrefs.scrollChild)
 vmPrefs.contentFrame:SetAllPoints(vmPrefs.scrollChild)
 vmPrefs.contentFrame.vmFrames = {}
 vmPrefs.contentFrame.vmMounts = {}
-vmPrefs.refresh = function (self)
-	createMountOptions(self)
-	self:SetScript("OnShow", createMountOptions)
-	self.refresh = function () return end
-end
+
+-- Build the options UI when the panel is shown
+vmPrefs:SetScript("OnShow", createMountOptions)
 
 
 


### PR DESCRIPTION
## Summary
- ensure the options UI builds when the panel is opened

## Testing
- `luacheck ValorMount/ValorMount.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0a6c10e8832ebfe36ee5c503d4c4