### PR TITLE
Fix zone override lookup

### DIFF
--- a/ValorMount/ValorMount.lua
+++ b/ValorMount/ValorMount.lua
@@ -314,11 +314,11 @@ do
 			end
 		end
 
-		-- Only loop softOverrides if necessary.
+                -- Only loop softOverrides if necessary.
                 if newValue or vmMain.zoneChanged then
                         for i = 1, #ValorMountGlobal.softOverrides do
                                 local zoneData = ValorMountGlobal.softOverrides[i]
-                                if zoneData[1] == vmMain.zoneInfo.instanceId and zoneData[2] == vmMain.zoneInfo.mapId and zoneData[3] == vmMain.zoneInfo.areaText then
+                                if zoneData[1] == vmMain.zoneInfo.instanceId and zoneData[2] == vmMain.zoneInfo.mapId then
                                         if newValue then
                                                 tremove(ValorMountGlobal.softOverrides, i)
                                                 vmMain.zoneInfo.zoneSoft = newValue
@@ -914,7 +914,7 @@ do
 		-- Flyable Area Override Help
 		f.titleHeaderFlyingInfo1 = f.titleHeaderFlyingInfo1 or mainFrame:CreateFontString(nil, 'ARTWORK', 'GameFontHighlightSmall')
 		f.titleHeaderFlyingInfo1:SetPoint('TOPLEFT', 20, mainFrame.fromTop)
-		f.titleHeaderFlyingInfo1:SetText("Use this to override how mounts are chosen for this specific area.")
+                f.titleHeaderFlyingInfo1:SetText("Use this to override how mounts are chosen for this zone.")
 		mainFrame.fromTop = mainFrame.fromTop - (f.titleHeaderFlyingInfo1:GetHeight() + 4) -- Smaller padding
 
 		-- Flyable Area Override Debug Information


### PR DESCRIPTION
## Summary
- allow zone override to ignore area text so it works across subzones
- adjust help text to mention zones

## Testing
- `luac -p ValorMount/ValorMount.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882e4abe4c832e86b3df0c3a16fb6d