### PR TITLE
Fix flyable area detection for ground mount selection

### DIFF
--- a/ValorMount/ValorMount.lua
+++ b/ValorMount/ValorMount.lua
@@ -314,18 +314,20 @@ do
 			end
 		end
 
-		-- Only loop softOverrides if necessary.
-		if newValue or vmMain.zoneChanged then
-			for i = 1, #ValorMountGlobal.softOverrides do
-				local zoneData = ValorMountGlobal.softOverrides[i]
-				if zoneData[1] == vmMain.zoneInfo.instanceId and zoneData[2] == vmMain.zoneInfo.mapId and zoneData[3] == vmMain.zoneInfo.areaText then
-					if newValue then
-						tremove(ValorMountGlobal.softOverrides, i)
-					end
-					vmMain.zoneInfo.zoneSoft = newValue or 1
-				end
-			end
-		end
+                -- Only loop softOverrides if necessary.
+                if newValue or vmMain.zoneChanged then
+                        for i = 1, #ValorMountGlobal.softOverrides do
+                                local zoneData = ValorMountGlobal.softOverrides[i]
+                                if zoneData[1] == vmMain.zoneInfo.instanceId and zoneData[2] == vmMain.zoneInfo.mapId and zoneData[3] == vmMain.zoneInfo.areaText then
+                                        if newValue then
+                                                tremove(ValorMountGlobal.softOverrides, i)
+                                                vmMain.zoneInfo.zoneSoft = newValue
+                                        else
+                                                vmMain.zoneInfo.zoneSoft = zoneData[4] or 1
+                                        end
+                                end
+                        end
+                end
 
 		-- Done
 		vmMain.zoneChanged = false
@@ -405,10 +407,11 @@ local function vmCanFly()
 		end
 	end
 
-	-- Cannot Fly Here
-	if not IsFlyableArea() or IsAdvancedFlyableArea() or IsInInstance() then
-		return false
-	end
+        -- Cannot Fly Here
+        local inInstance, instanceType = IsInInstance()
+        if not IsFlyableArea() or IsAdvancedFlyableArea() or (inInstance and instanceType ~= "none") then
+                return false
+        end
 
 	-- To Infinity, and Beyond!
 	return true


### PR DESCRIPTION
## Summary
- respect stored zone overrides when determining flight availability
- check instance type to avoid treating non-flyable areas as flyable

## Testing
- `luac -p ValorMount/ValorMount.lua`


------
https://chatgpt.com/codex/tasks/task_e_68aba4df7fb4832eb43192b5578fac55